### PR TITLE
Migrate file picker from mpfilepicker to FileKit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 **/build/
 .gradle
 **/.idea/*
+.kotlin
+yarn.lock
 
 *.xcworkspacedata
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,6 +62,8 @@ kotlin {
             api(libs.compose.window.size)
 
             api(libs.generativeai)
+
+            implementation(libs.filekit.compose)
         }
 
         androidMain.dependencies {
@@ -69,16 +71,10 @@ kotlin {
             implementation(libs.androidx.activity.compose)
 
             implementation(libs.voyager)
-            implementation(libs.mpfilepicker)
         }
 
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)
-            implementation(libs.mpfilepicker)
-        }
-
-        appleMain.dependencies {
-            implementation(libs.mpfilepicker)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/actual.kt
+++ b/composeApp/src/androidMain/kotlin/actual.kt
@@ -1,55 +1,7 @@
-import android.content.ContentResolver
 import android.graphics.BitmapFactory
-import android.net.Uri
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
-import com.darkrockstudios.libraries.mpfilepicker.FilePicker
-import com.darkrockstudios.libraries.mpfilepicker.MPFile
-import com.mikepenz.markdown.m3.Markdown
-import kotlinx.coroutines.launch
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
-
 
 actual fun ByteArray.toComposeImageBitmap(): ImageBitmap {
     return BitmapFactory.decodeByteArray(this, 0, size).asImageBitmap()
-}
-
-
-@OptIn(ExperimentalEncodingApi::class)
-@Composable
-actual fun ImagePicker(
-    show: Boolean,
-    initialDirectory: String?,
-    title: String?,
-    onImageSelected: ImageFileImported,
-) {
-    val coroutineScope = rememberCoroutineScope()
-    val contentResolver = LocalContext.current.contentResolver
-
-    val fileExtensions = listOf("jpg", "png")
-    FilePicker(show = show, fileExtensions = fileExtensions) { file ->
-        coroutineScope.launch {
-            file?.let {
-                val imageData = getImageByteArray(file, contentResolver)
-                imageData?.let {
-                    onImageSelected(file.path, imageData)
-                }
-            }
-        }
-    }
-}
-
-
-fun getImageByteArray(file: MPFile<Any>, contentResolver: ContentResolver): ByteArray? {
-    val uri = Uri.parse(file.path)
-    val stream = contentResolver.openInputStream(uri)
-    stream?.let {
-        val bytes = stream.readBytes()
-        stream.close()
-        return bytes
-    } ?: return null
 }

--- a/composeApp/src/commonMain/kotlin/App.kt
+++ b/composeApp/src/commonMain/kotlin/App.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.m3.Markdown
 import dev.shreyaspatil.ai.client.generativeai.type.GenerateContentResponse
+import io.github.vinceglb.filekit.compose.rememberFilePickerLauncher
+import io.github.vinceglb.filekit.core.PickerType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
@@ -51,12 +53,20 @@ fun App() {
     var selectedImageData by remember { mutableStateOf<ByteArray?>(null) }
     var content by remember { mutableStateOf("") }
     var showProgress by remember { mutableStateOf(false) }
-    var showImagePicker by remember { mutableStateOf(false) }
     var filePath by remember { mutableStateOf("") }
     var image by remember { mutableStateOf<ImageBitmap?>(null) }
     val canClearPrompt by remember {
         derivedStateOf {
             prompt.isNotBlank()
+        }
+    }
+
+    val imagePickerLauncher = rememberFilePickerLauncher(PickerType.Image) { selectedImage ->
+        coroutineScope.launch {
+            val bytes = selectedImage?.readBytes()
+            selectedImageData = bytes
+            image = bytes?.toComposeImageBitmap()
+            filePath = selectedImage?.path ?: ""
         }
     }
 
@@ -116,7 +126,7 @@ fun App() {
                 }
 
                 OutlinedButton(
-                    onClick = { showImagePicker = true },
+                    onClick = { imagePickerLauncher.launch() },
                     modifier = Modifier
                         .padding(all = 4.dp)
                         .weight(1f)
@@ -147,15 +157,6 @@ fun App() {
                         .align(Alignment.CenterVertically)
                 ) {
                     Text("Generate Compose UI Code")
-                }
-
-                ImagePicker(show = showImagePicker) { file, imageData ->
-                    showImagePicker = false
-                    filePath = file
-                    selectedImageData = imageData
-                    imageData?.let {
-                        image = imageData.toComposeImageBitmap()
-                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/GeminiApi.kt
+++ b/composeApp/src/commonMain/kotlin/GeminiApi.kt
@@ -21,7 +21,7 @@ class GeminiApi {
 
 
     val generativeVisionModel = GenerativeModel(
-        modelName = "gemini-pro-vision",
+        modelName = "gemini-1.5-flash",
         apiKey = apiKey
     )
 

--- a/composeApp/src/commonMain/kotlin/expect.kt
+++ b/composeApp/src/commonMain/kotlin/expect.kt
@@ -1,15 +1,3 @@
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.ImageBitmap
 
 expect fun ByteArray.toComposeImageBitmap(): ImageBitmap
-
-
-typealias ImageFileImported = (filePath: String, data: ByteArray?) -> Unit
-
-@Composable
-expect fun ImagePicker(
-    show: Boolean,
-    initialDirectory: String? = null,
-    title: String? = null,
-    onImageSelected: ImageFileImported
-)

--- a/composeApp/src/desktopMain/kotlin/actual.kt
+++ b/composeApp/src/desktopMain/kotlin/actual.kt
@@ -1,29 +1,5 @@
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
-import com.darkrockstudios.libraries.mpfilepicker.FilePicker
-import com.mikepenz.markdown.m3.Markdown
-import kotlinx.coroutines.launch
 import org.jetbrains.skia.Image
 
 actual fun ByteArray.toComposeImageBitmap(): ImageBitmap = Image.makeFromEncoded(this).toComposeImageBitmap()
-
-@Composable
-actual fun ImagePicker(
-    show: Boolean,
-    initialDirectory: String?,
-    title: String?,
-    onImageSelected: ImageFileImported,
-) {
-    val coroutineScope = rememberCoroutineScope()
-
-    val fileExtensions = listOf("jpg", "png")
-    FilePicker(show = show, fileExtensions = fileExtensions) { file ->
-        coroutineScope.launch {
-            file?.getFileByteArray()?.let { imageData ->
-                onImageSelected(file.path, imageData)
-            }
-        }
-    }
-}

--- a/composeApp/src/iosMain/kotlin/actual.kt
+++ b/composeApp/src/iosMain/kotlin/actual.kt
@@ -1,64 +1,8 @@
-@file:OptIn(ExperimentalForeignApi::class, ExperimentalEncodingApi::class)
-
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
-import com.darkrockstudios.libraries.mpfilepicker.FilePicker
-import com.mikepenz.markdown.m3.Markdown
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.usePinned
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
 import org.jetbrains.skia.Image
-import platform.Foundation.NSData
-import platform.Foundation.NSURL
-import platform.Foundation.dataWithContentsOfURL
-import platform.posix.memcpy
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 
 actual fun ByteArray.toComposeImageBitmap(): ImageBitmap {
     return Image.makeFromEncoded(this).toComposeImageBitmap()
-}
-
-@Composable
-actual fun ImagePicker(
-    show: Boolean,
-    initialDirectory: String?,
-    title: String?,
-    onImageSelected: ImageFileImported,
-) {
-    val coroutineScope = rememberCoroutineScope()
-
-    val fileExtensions = listOf("jpg", "png")
-    FilePicker(show = show, fileExtensions = fileExtensions) { file ->
-        coroutineScope.launch {
-            file?.let {
-                val platformFile = file.platformFile as NSURL
-                val imageData = platformFile.readBytes()
-                onImageSelected(file.path, imageData)
-            }
-        }
-    }
-}
-
-suspend fun NSURL.readBytes(): ByteArray =
-    with(readData()) {
-        ByteArray(length.toInt()).apply {
-            usePinned {
-                memcpy(it.addressOf(0), bytes, length)
-            }
-        }
-    }
-
-suspend fun NSURL.readData(): NSData {
-    while (true) {
-        val data = NSData.dataWithContentsOfURL(this)
-        if (data != null)
-            return data
-        yield()
-    }
 }

--- a/composeApp/src/wasmJsMain/kotlin/actual.kt
+++ b/composeApp/src/wasmJsMain/kotlin/actual.kt
@@ -1,77 +1,7 @@
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
-import kotlinx.browser.document
 import org.jetbrains.skia.Image
-import org.khronos.webgl.ArrayBuffer
-import org.khronos.webgl.Uint8Array
-import org.khronos.webgl.get
-import org.w3c.dom.HTMLInputElement
-import org.w3c.files.FileReader
-import org.w3c.files.get
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
-
 
 actual fun ByteArray.toComposeImageBitmap(): ImageBitmap {
     return Image.makeFromEncoded(this).toComposeImageBitmap()
-}
-
-
-@Composable
-actual fun ImagePicker(
-    show: Boolean,
-    initialDirectory: String?,
-    title: String?,
-    onImageSelected: ImageFileImported,
-) {
-    LaunchedEffect(show) {
-        if (show) {
-            val data = importImageFile()
-            onImageSelected("", data)
-        }
-    }
-}
-
-
-private suspend fun importImageFile(): ByteArray? {
-    return try {
-        pickFile()
-    } catch (e: Exception) {
-        e.printStackTrace()
-        null
-    }
-}
-
-private suspend fun pickFile(): ByteArray? = suspendCoroutine { cont ->
-    try {
-        val input = document.createElement("input").apply {
-            setAttribute("type", "file")
-            setAttribute("accept", "image/*")
-        } as HTMLInputElement
-
-        input.onchange = {
-            val file = input.files?.get(0)
-            if (file != null) {
-                val reader = FileReader()
-                reader.onload = { event ->
-                    val arrayBuffer = (event.target as FileReader).result as ArrayBuffer
-                    val array = Uint8Array(arrayBuffer)
-
-                    cont.resume(ByteArray(array.length) { array[it] })
-                }
-                reader.onerror = {
-                    cont.resumeWithException(Exception(reader.error.toString()))
-                }
-                reader.readAsArrayBuffer(file)
-            } else {
-                cont.resumeWithException(Exception("No file was selected"))
-            }
-        }
-        input.click()
-    } catch (e: Exception) {
-        cont.resumeWithException(e)
-    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
-kotlin = "2.0.0"
+kotlin = "2.0.10"
 kotlinx-coroutines = "1.8.1"
 
 
-agp = "8.4.1"
+agp = "8.5.2"
 android-compileSdk = "34"
 android-minSdk = "24"
 android-targetSdk = "34"
@@ -11,12 +11,12 @@ androidx-activityCompose = "1.9.0"
 compose = "1.6.7"
 compose-plugin = "1.6.10"
 composeWindowSize = "0.5.0"
+filekit = "0.8.0"
 generativeai = "0.5.0-1.0.0-wasm"
 horologist = "0.6.12"
 junit = "4.13.2"
 voyager= "1.0.0"
 buildkonfig = "0.15.1"
-mpFilePicker = "3.1.0"
 markdownRenderer = "0.16.0"
 wearCompose = "1.3.1"
 
@@ -32,7 +32,9 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = 
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-window-size = { module = "dev.chrisbanes.material3:material3-window-size-class-multiplatform", version.ref = "composeWindowSize" }
-mpfilepicker = { module = "com.darkrockstudios:mpfilepicker", version.ref = "mpFilePicker" }
+
+filekit-compose = { module = "io.github.vinceglb:filekit-compose", version.ref = "filekit" }
+
 markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 markdown-renderer-core = { module = "com.mikepenz:multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
[MPFilePicker](https://github.com/Wavesonics/compose-multiplatform-file-picker) is now archived.

An alternative solution is to use [FileKit](https://github.com/vinceglb/FileKit):
- One of the benefits is that it targets Android, iOS, macOS, JVM and also WASM
- It uses native file system dialogs even on JVM thanks to [JNA](https://github.com/java-native-access/jna)
- We can easily access file bytes from the common code

I thought it was a good idea to share this migration with you 😄

PS: I updated generative vision model because `gemini-pro-vision` is deprecated and returns an exception now.